### PR TITLE
Added .travis.yml config file for travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+jdk:
+  - oraclejdk7
+
+script: cd MovieFinder && mvn install -DskipTests=true && mvn test
+
+branches:
+    only:
+        - master
+        - develop
+
+notifications:
+    email: false


### PR DESCRIPTION
Added a .travis.yml config file for Travis-CI. 

Travis-CI builds and runs tests (it clones our repo, then runs `mvn install` and `mvn test`). As configured now it should only build on pull requests, giving us an indication if the pull request is good or not. 

Travis also requires;
- The Travis-CI service to be enabled for the project by admin @we4sz. Settings -> Webhooks & services -> Travis-CI under services.
- A Travis-CI pro account, since this is a private repo. There is a free trial (without any credit card requirements) for 100 builds, which should be enough?
