### PR TITLE
Jpa database base

### DIFF
--- a/MovieFinder/pom.xml
+++ b/MovieFinder/pom.xml
@@ -17,6 +17,7 @@
         <org.aspectj-version>1.8.2</org.aspectj-version>
         <org.slf4j-version>1.7.7</org.slf4j-version>
         <jackson.databind-version>2.4.2</jackson.databind-version>
+        <org.hamcrest-version>1.3</org.hamcrest-version>
         <java-version>1.7</java-version>
     </properties>
     <dependencies>
@@ -26,6 +27,7 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.databind-version}</version>
         </dependency>
+
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework</groupId>
@@ -43,6 +45,57 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
             <version>${org.springframework-version}</version>
+        </dependency>
+
+        <!-- Spring Data JPA -->
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-jpa</artifactId>
+            <version>1.7.0.RELEASE</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-orm</artifactId>
+            <version>${org.springframework-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+            <version>${org.springframework-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+            <version>${org.springframework-version}</version>
+        </dependency>
+        
+        <!-- Hibernate -->
+        <dependency>
+            <groupId>org.hibernate.javax.persistence</groupId>
+            <artifactId>hibernate-jpa-2.0-api</artifactId>
+            <version>1.0.1.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+            <version>4.1.9.Final</version>
+            <scope>runtime</scope>
+        </dependency>
+		
+        <!-- Querydsl -->
+        <dependency>
+            <groupId>com.mysema.querydsl</groupId>
+            <artifactId>querydsl-jpa</artifactId>
+            <version>3.5.0</version>
+        </dependency>
+
+        <!-- HSQL -->
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>2.2.9</version>
+            <scope>runtime</scope>
         </dependency>
  
         <!-- AspectJ -->
@@ -119,9 +172,27 @@
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
             <version>1.2</version>
+        </dependency>       
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.0.1</version>
+            <type>jar</type>
         </dependency>
- 
+        
         <!-- Test -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${org.hamcrest-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${org.hamcrest-version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -129,13 +200,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
-            <type>jar</type>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${org.springframework-version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
-
     
     <repositories>
         <repository>

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/ApplicationConfig.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/ApplicationConfig.java
@@ -1,0 +1,63 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package edu.chalmers.dat076.moviefinder;
+
+import javax.sql.DataSource;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.Database;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ *
+ * @author Peter
+ * This class sets up the database data source and various other things related
+ * to the database. See https://github.com/spring-projects/spring-data-book/blob/master/jpa/src/main/java/com/oreilly/springdata/jpa/InfrastructureConfig.java 
+ * and http://docs.spring.io/spring-data/jpa/docs/1.7.0.RELEASE/reference/html/#jpa.java-config
+ */
+@Configuration
+@EnableJpaRepositories
+@EnableTransactionManagement
+public class ApplicationConfig {
+
+    @Bean
+    public DataSource dataSource() {
+
+        EmbeddedDatabaseBuilder builder = new EmbeddedDatabaseBuilder();
+        return builder.setType(EmbeddedDatabaseType.HSQL).build();
+    }
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
+
+        HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+        vendorAdapter.setDatabase(Database.HSQL);
+        vendorAdapter.setGenerateDdl(true);
+
+        LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
+        factory.setJpaVendorAdapter(vendorAdapter);
+        factory.setPackagesToScan(getClass().getPackage().getName());
+        factory.setDataSource(dataSource());
+
+        return factory;
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager() {
+
+        JpaTransactionManager txManager = new JpaTransactionManager();
+        txManager.setEntityManagerFactory(entityManagerFactory().getObject());
+        return txManager;
+    }
+}

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/persistence/AbstractEntity.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/persistence/AbstractEntity.java
@@ -1,0 +1,49 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package edu.chalmers.dat076.moviefinder.persistence;
+
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
+/**
+ * A class for handling ID of entities.
+ * 
+ * @author Peter
+ */
+@MappedSuperclass
+public class AbstractEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+
+        if (this == obj) {
+            return true;
+        }
+
+        if (this.id == null || obj == null || !(this.getClass().equals(obj.getClass()))) {
+            return false;
+        }
+
+        AbstractEntity that = (AbstractEntity) obj;
+
+        return this.id.equals(that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return id == null ? 0 : id.hashCode();
+    }
+}

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/persistence/Movie.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/persistence/Movie.java
@@ -1,0 +1,58 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package edu.chalmers.dat076.moviefinder.persistence;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+
+/**
+ * A movie entity.
+ * 
+ * @author Peter
+ */
+@Entity
+public class Movie extends AbstractEntity {
+
+    @Column(nullable = false)
+    private String title;
+    
+    private Double imdbRating;
+    
+    @ElementCollection(fetch = FetchType.EAGER)
+    private Set<String> genres = new HashSet<>();
+
+    protected Movie() {
+    }
+    
+    public Movie(String title) {
+        this(title, null, null);
+    }
+    
+    public Movie(String title, Double imdbRating, Set<String> genres) {
+        this.title = title;
+        this.imdbRating = imdbRating;
+        if(genres != null) {
+            this.genres = new HashSet<>(genres);
+        }
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Double getImdbRating() {
+        return imdbRating;
+    }
+
+    public Set<String> getGenres() {
+        return Collections.unmodifiableSet(genres);
+    }
+}

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/persistence/MovieRepository.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/persistence/MovieRepository.java
@@ -1,0 +1,23 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package edu.chalmers.dat076.moviefinder.persistence;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * A movie repository. Note that this interface is automagically implemented
+ * by spring-data. The method names are used by spring to generate the queries,
+ * see http://docs.spring.io/spring-data/jpa/docs/1.7.0.RELEASE/reference/html/#jpa.query-methods
+ * for all available query methods.
+ * 
+ * @author Peter
+ */
+public interface MovieRepository extends CrudRepository<Movie, Long> {
+    public Page<Movie> findByTitleContaining(String name, Pageable pageable);
+    
+}

--- a/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/AbstractIntegrationTest.java
+++ b/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/AbstractIntegrationTest.java
@@ -1,0 +1,55 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package edu.chalmers.dat076.moviefinder;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Base class for integration tests that populates the database with . 
+ * 
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@Transactional
+public abstract class AbstractIntegrationTest {
+
+	@Autowired
+	DataSource dataSource;
+
+	/**
+	 * Populates the configured {@link DataSource} with data from {@code data.sql}.
+	 * 
+	 * @throws SQLException
+	 */
+	@Before 
+	public void populateDatabase() throws SQLException {
+
+		ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+		populator.addScript(new ClassPathResource("data.sql"));
+
+		Connection connection = null;
+
+		try {
+			connection = DataSourceUtils.getConnection(dataSource);
+			populator.populate(connection);
+		} finally {
+			if (connection != null) {
+				DataSourceUtils.releaseConnection(connection, dataSource);
+			}
+		}
+	}
+}

--- a/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/ApplicationConfigTest.java
+++ b/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/ApplicationConfigTest.java
@@ -1,0 +1,33 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package edu.chalmers.dat076.moviefinder;
+
+import edu.chalmers.dat076.moviefinder.persistence.MovieRepository;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * Tests the application config. This is done by first loading the application
+ * config, then testing if we can get a known bean or not.
+ * 
+ * See https://github.com/spring-projects/spring-data-book/blob/master/jpa/src/test/java/com/oreilly/springdata/jpa/ApplicationConfigTest.java 
+ * @author Peter
+ */
+public class ApplicationConfigTest {
+
+	@Test
+	public void bootstrapApp() {
+		ApplicationContext context = new AnnotationConfigApplicationContext(ApplicationConfig.class);
+		assertThat(context, is(notNullValue()));
+		assertThat(context.getBean(MovieRepository.class), is(notNullValue()));
+	}
+
+}

--- a/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/TestApplicationConfig.java
+++ b/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/TestApplicationConfig.java
@@ -1,0 +1,62 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package edu.chalmers.dat076.moviefinder;
+
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.Database;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ *
+ * Application config used for the tests. For example uses an in-memory db instead
+ * of a real one.
+ * 
+ * @author Peter
+ */
+@Configuration
+@EnableJpaRepositories
+@EnableTransactionManagement
+public class TestApplicationConfig {
+
+    @Bean
+    public DataSource dataSource() {
+
+        EmbeddedDatabaseBuilder builder = new EmbeddedDatabaseBuilder();
+        return builder.setType(EmbeddedDatabaseType.HSQL).build();
+    }
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
+
+        HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+        vendorAdapter.setDatabase(Database.HSQL);
+        vendorAdapter.setGenerateDdl(true);
+
+        LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
+        factory.setJpaVendorAdapter(vendorAdapter);
+        factory.setPackagesToScan(getClass().getPackage().getName());
+        factory.setDataSource(dataSource());
+
+        return factory;
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager() {
+
+        JpaTransactionManager txManager = new JpaTransactionManager();
+        txManager.setEntityManagerFactory(entityManagerFactory().getObject());
+        return txManager;
+    }
+}

--- a/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/persistence/MovieRepositoryIntegrationTest.java
+++ b/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/persistence/MovieRepositoryIntegrationTest.java
@@ -1,0 +1,44 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package edu.chalmers.dat076.moviefinder.persistence;
+
+import edu.chalmers.dat076.moviefinder.AbstractIntegrationTest;
+import edu.chalmers.dat076.moviefinder.TestApplicationConfig;
+import org.hamcrest.Matchers;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ *
+ * @author Peter
+ */
+@ContextConfiguration(classes = TestApplicationConfig.class)
+public class MovieRepositoryIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    MovieRepository repository;
+
+    @Test
+    public void createMovie() {
+        Movie movie = new Movie("MovieTest2");
+        repository.save(movie);
+    }
+    
+    @Test
+    public void findByTitleContaining() {
+        Pageable pageable = new PageRequest(0, 1);
+        Page<Movie> page = repository.findByTitleContaining("testMovie", pageable);
+        
+        assertThat(page.getContent(), hasSize(1));
+        assertThat(page, Matchers.<Movie> hasItems(hasProperty("title", is("testMovie1"))));
+    }
+}

--- a/MovieFinder/src/test/resources/data.sql
+++ b/MovieFinder/src/test/resources/data.sql
@@ -1,0 +1,1 @@
+insert into Movie (id, title) values (1, 'testMovie1');


### PR DESCRIPTION
Set up base structure for a JPA based database using spring-data. The setup used is much the same as https://github.com/spring-projects/spring-data-book/tree/master/jpa. 

The ApplicationConfig.java file defines the database used. There is no persistence.xml file, nor any other configuration in .xml files.

The Movie entity is a normal JPA entity, the same as used in exercise 4. However, the fetching of the data is built on [repositories](http://docs.spring.io/spring-data/jpa/docs/1.7.0.RELEASE/reference/html/#repositories.core-concepts). These are interfaces (that mosty likely all will be) extending [CrudRepository](http://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/CrudRepository.html)  and then adding methods whose names are written in a specific way. Spring-data then generates the implementation for us by looking at the names of the methods. See the [Query creation](http://docs.spring.io/spring-data/jpa/docs/1.7.0.RELEASE/reference/html/#jpa.query-methods) section of the spring-data docs for the special naming conventions used.

Currently both the tests and the real app uses HSQLDB in in-memory mode. Should investigate how one would use something else for the real app, such as java-db.
