### PR TITLE
Backend db integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ bower_components
 
 # The front end build directory
 MovieFinder/src/main/webapp/build
+
+# Application properties
+MovieFinder/src/main/resources/application.properties

--- a/MovieFinder/pom.xml
+++ b/MovieFinder/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
-            <version>4.1.9.Final</version>
+            <version>4.3.6.Final</version>
             <scope>runtime</scope>
         </dependency>
 		

--- a/MovieFinder/pom.xml
+++ b/MovieFinder/pom.xml
@@ -106,7 +106,7 @@
         <!-- Derby -->
         <dependency>
             <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
+            <artifactId>derbyclient</artifactId>
             <version>10.11.1.1</version>
             <scope>runtime</scope>
         </dependency>

--- a/MovieFinder/pom.xml
+++ b/MovieFinder/pom.xml
@@ -111,6 +111,14 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- Derby embedded -->
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>10.11.1.1</version>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- AspectJ -->
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/ApplicationConfig.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/ApplicationConfig.java
@@ -1,0 +1,26 @@
+package edu.chalmers.dat076.moviefinder.config;
+
+import edu.chalmers.dat076.moviefinder.service.FileThreadService;
+import edu.chalmers.dat076.moviefinder.utils.TitleParser;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Created by Peter on 2014-10-17.
+ */
+@Configuration
+@Import({RepositoryConfig.class, WebConfig.class})
+public class ApplicationConfig {
+
+    @Bean(name = "FileThreadService", destroyMethod = "destory")
+    public FileThreadService fileThreadService() {
+        return new FileThreadService();
+    }
+
+    @Bean
+    public TitleParser titleParser() {
+        return new TitleParser();
+    }
+
+}

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/ApplicationConfig.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/ApplicationConfig.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Import;
 @Import({RepositoryConfig.class, WebConfig.class})
 public class ApplicationConfig {
 
-    @Bean(name = "FileThreadService", destroyMethod = "destory")
+    @Bean
     public FileThreadService fileThreadService() {
         return new FileThreadService();
     }

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/ApplicationConfig.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/ApplicationConfig.java
@@ -2,9 +2,11 @@ package edu.chalmers.dat076.moviefinder.config;
 
 import edu.chalmers.dat076.moviefinder.service.FileThreadService;
 import edu.chalmers.dat076.moviefinder.utils.TitleParser;
+import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.io.ClassPathResource;
 
 /**
  * Created by Peter on 2014-10-17.
@@ -12,6 +14,14 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @Import({RepositoryConfig.class, WebConfig.class})
 public class ApplicationConfig {
+
+    @Bean
+    PropertyPlaceholderConfigurer getPropertyPlaceholderConfigurer() {
+        PropertyPlaceholderConfigurer ppc = new PropertyPlaceholderConfigurer();
+        ppc.setLocation(new ClassPathResource("application.properties"));
+        ppc.setIgnoreUnresolvablePlaceholders(true);
+        return ppc;
+    }
 
     @Bean
     public FileThreadService fileThreadService() {
@@ -22,5 +32,4 @@ public class ApplicationConfig {
     public TitleParser titleParser() {
         return new TitleParser();
     }
-
 }

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/RepositoryConfig.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/RepositoryConfig.java
@@ -36,10 +36,10 @@ public class RepositoryConfig {
     @Bean
     public DataSource dataSource() {
         DriverManagerDataSource ds = new DriverManagerDataSource();
-        ds.setDriverClassName("org.apache.derby.jdbc.EmbeddedDriver");
-        ds.setUrl("jdbc:derby:derbyDB;create=true");
-        ds.setUsername(null);
-        ds.setPassword(null);
+        ds.setDriverClassName("org.apache.derby.jdbc.ClientDriver");
+        ds.setUrl("jdbc:derby://localhost:1527/MovieFinder;create=true");
+        ds.setUsername("app");
+        ds.setPassword("app");
         return ds;
     }
 

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/RepositoryConfig.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/RepositoryConfig.java
@@ -5,21 +5,20 @@
  */
 package edu.chalmers.dat076.moviefinder.config;
 
-import javax.sql.DataSource;
-
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.Database;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+import java.util.Properties;
 
 /**
  *
@@ -33,15 +32,44 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 public class RepositoryConfig {
 
+    @Value("${jdbc.driverClassName}")
+    private String jdbcDriverClassName;
+
+    @Value("${jdbc.url}")
+    private String jdbcUrl;
+
+    @Value("${jdbc.username}")
+    private String jdbcUsername;
+
+    @Value("${jdbc.password}")
+    private String jdbcPassword;
+
+    @Value("${hibernate.dialect}")
+    private String hibernateDialect;
+
+    @Value("${hibernate.hbm2ddl.auto}")
+    private String hibernateHbm2ddlAuto;
+
+    @Value("${hibernate.show_sql}")
+    private String hibernateShowSql;
+
+    @Value("${hibernate.format_sql}")
+    private String hibernateFormatSql;
+
+    @Value("${hibernate.use_sql_comments}")
+    private String hibernateUseSqlComments;
+
+
     @Bean
     public DataSource dataSource() {
         DriverManagerDataSource ds = new DriverManagerDataSource();
-        ds.setDriverClassName("org.apache.derby.jdbc.ClientDriver");
-        ds.setUrl("jdbc:derby://localhost:1527/MovieFinder;create=true");
-        ds.setUsername("app");
-        ds.setPassword("app");
+        ds.setDriverClassName(jdbcDriverClassName);
+        ds.setUrl(jdbcUrl);
+        ds.setUsername(jdbcUsername);
+        ds.setPassword(jdbcPassword);
         return ds;
     }
+
 
     @Bean
     public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
@@ -50,10 +78,20 @@ public class RepositoryConfig {
         vendorAdapter.setDatabase(Database.DERBY);
         vendorAdapter.setGenerateDdl(true);
 
+
+        Properties jpaProperties = new Properties();
+        jpaProperties.setProperty("hibernate.dialect", hibernateDialect);
+        jpaProperties.setProperty("hibernate.hbm2ddl.auto", hibernateHbm2ddlAuto);
+        jpaProperties.setProperty("hibernate.show_sql", hibernateShowSql);
+        jpaProperties.setProperty("hibernate.format_sql", hibernateFormatSql);
+        jpaProperties.setProperty("hibernate.use_sql_comments", hibernateUseSqlComments);
+
+
         LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
         factory.setJpaVendorAdapter(vendorAdapter);
-        factory.setPackagesToScan("edu.chalmers.dat076.moviefinder");
+        factory.setPackagesToScan("edu.chalmers.dat076.moviefinder.persistence");
         factory.setDataSource(dataSource());
+        factory.setJpaProperties(jpaProperties);
 
         return factory;
     }

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/SecurityConfig.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/SecurityConfig.java
@@ -18,7 +18,6 @@ import org.springframework.security.web.header.writers.StaticHeadersWriter;
  */
 @Configuration
 @EnableWebMvcSecurity
-@ComponentScan("edu.chalmers.dat076.moviefinder")
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/WebConfig.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/WebConfig.java
@@ -17,7 +17,7 @@ import org.springframework.web.servlet.view.InternalResourceViewResolver;
 
 @Configuration
 @EnableWebMvc
-@ComponentScan("edu.chalmers.dat076.moviefinder.controller")
+@ComponentScan(basePackages = { "edu.chalmers.dat076.moviefinder.controller", "edu.chalmers.dat076.moviefinder.filter" })
 public class WebConfig extends WebMvcConfigurerAdapter {
 
     @Override
@@ -46,15 +46,4 @@ public class WebConfig extends WebMvcConfigurerAdapter {
         viewResolver.setSuffix(".jsp");
         return viewResolver;
     }
-
-    @Bean(name = "FileThreadService", initMethod = "init", destroyMethod = "destory")
-    public FileThreadService fileThreadService() {
-        return new FileThreadService();
-    }
-
-    @Bean
-    public TitleParser titleParser() {
-        return new TitleParser();
-    }
-
 }

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/WebConfig.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/config/WebConfig.java
@@ -6,6 +6,7 @@
 package edu.chalmers.dat076.moviefinder.config;
 
 import edu.chalmers.dat076.moviefinder.service.FileThreadService;
+import edu.chalmers.dat076.moviefinder.utils.TitleParser;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -19,14 +20,6 @@ import org.springframework.web.servlet.view.InternalResourceViewResolver;
 @ComponentScan("edu.chalmers.dat076.moviefinder.controller")
 public class WebConfig extends WebMvcConfigurerAdapter {
 
-    @Bean
-    InternalResourceViewResolver setViewResolver() {
-        InternalResourceViewResolver viewResolver = new InternalResourceViewResolver();
-        viewResolver.setPrefix("/WEB-INF/views/");
-        viewResolver.setSuffix(".jsp");
-        return viewResolver;
-    }
-
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
 
@@ -34,7 +27,7 @@ public class WebConfig extends WebMvcConfigurerAdapter {
         registry.addResourceHandler("/build/**")
                 .addResourceLocations("/build/")
                 .setCachePeriod(31556926);
-                
+
         // TODO: The following two routes are only needed for index-dev
         // Used for direct references instead of having to build whenever
         // a file changes.
@@ -46,9 +39,22 @@ public class WebConfig extends WebMvcConfigurerAdapter {
         super.addResourceHandlers(registry);
     }
 
+    @Bean
+    InternalResourceViewResolver setViewResolver() {
+        InternalResourceViewResolver viewResolver = new InternalResourceViewResolver();
+        viewResolver.setPrefix("/WEB-INF/views/");
+        viewResolver.setSuffix(".jsp");
+        return viewResolver;
+    }
+
     @Bean(name = "FileThreadService", initMethod = "init", destroyMethod = "destory")
     public FileThreadService fileThreadService() {
         return new FileThreadService();
+    }
+
+    @Bean
+    public TitleParser titleParser() {
+        return new TitleParser();
     }
 
 }

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/controller/FileController.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/controller/FileController.java
@@ -5,8 +5,13 @@
  */
 package edu.chalmers.dat076.moviefinder.controller;
 
+import edu.chalmers.dat076.moviefinder.persistence.Movie;
+import edu.chalmers.dat076.moviefinder.persistence.MovieRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  *
@@ -16,5 +21,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 @RequestMapping("api/files")
 public class FileController {
-    
+
+    @Autowired
+    MovieRepository movieRepository;
+
+    @RequestMapping(value = "/", method = RequestMethod.GET)
+    public @ResponseBody
+    Iterable<Movie> listMovies() {
+        return movieRepository.findAll();
+    }
 }

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/filter/UserFilter.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/filter/UserFilter.java
@@ -7,66 +7,51 @@ package edu.chalmers.dat076.moviefinder.filter;
 
 import edu.chalmers.dat076.moviefinder.model.User;
 import edu.chalmers.dat076.moviefinder.model.UserRole;
-import java.io.IOException;
-import javax.servlet.Filter;
+import org.springframework.web.filter.OncePerRequestFilter;
+
 import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.annotation.WebFilter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import org.springframework.context.annotation.Configuration;
+import java.io.IOException;
 
 /**
  *
  * @author John
  */
-@Configuration
 @WebFilter("/*")
-public class UserFilter implements Filter {
+public class UserFilter extends OncePerRequestFilter {
 
     @Override
-    public void doFilter(ServletRequest req, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        HttpServletRequest request = (HttpServletRequest) req;
-        HttpServletResponse httpResponse = (HttpServletResponse) response;
-        HttpSession session = request.getSession(true);
-        String path = request.getRequestURI();
-
-        System.out.println(path);
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws ServletException, IOException {
+        HttpSession session = req.getSession(true);
+        String path = req.getRequestURI().substring(req.getContextPath().length());
 
         Object o = session.getAttribute("user");
 
         if (o == null) {
-            if (path.toLowerCase().startsWith("/moviefinder/api/login/login")) {
-                chain.doFilter(req, response);
+            if (path.toLowerCase().startsWith("/api/login/login")) {
+                chain.doFilter(req, res);
                 return;
-            } else if (path.toLowerCase().startsWith("/moviefinder/api/")) {
-                httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            } else if (path.toLowerCase().startsWith("/api/")) {
+                res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 return;
             } else {
-                chain.doFilter(req, response);
+                chain.doFilter(req, res);
                 return;
             }
         }
 
         User u = (User) o;
         if (path.contains("/admin") && u.getRole() != UserRole.ADMIN) {
-            httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }
 
-        chain.doFilter(req, response);
+        chain.doFilter(req, res);
     }
 
-    @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
-    }
-
-    @Override
-    public void destroy() {
-    }
 
 }

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/initializer/ProjectWebApplicationInitializer.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/initializer/ProjectWebApplicationInitializer.java
@@ -5,6 +5,8 @@
  */
 package edu.chalmers.dat076.moviefinder.initializer;
 
+import edu.chalmers.dat076.moviefinder.config.ApplicationConfig;
+import edu.chalmers.dat076.moviefinder.config.RepositoryConfig;
 import edu.chalmers.dat076.moviefinder.config.WebConfig;
 
 import javax.servlet.ServletContext;
@@ -25,7 +27,7 @@ public class ProjectWebApplicationInitializer implements WebApplicationInitializ
         // Create the 'root' Spring application context
         AnnotationConfigWebApplicationContext applicationContext
                 = new AnnotationConfigWebApplicationContext();
-        applicationContext.register(WebConfig.class);
+        applicationContext.register(ApplicationConfig.class);
 
         // Register and map the dispatcher servlet
         ServletRegistration.Dynamic dispatcher = container.addServlet("dispatcher", 

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/model/TemporaryMedia.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/model/TemporaryMedia.java
@@ -61,5 +61,16 @@ public class TemporaryMedia {
     public int getYear(){
         return year;
     }
-    
+
+
+    @Override
+    public String toString() {
+        return "TemporaryMedia{" +
+                "name='" + name + '\'' +
+                ", isMovie=" + isMovie +
+                ", year=" + year +
+                ", season=" + season +
+                ", episode=" + episode +
+                '}';
+    }
 }

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/persistence/Movie.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/persistence/Movie.java
@@ -23,25 +23,23 @@ public class Movie extends AbstractEntity {
 
     @Column(nullable = false)
     private String title;
+
+    @Column(nullable = false, unique = true)
+    private String filePath;
     
     private Double imdbRating;
-    
-    @ElementCollection(fetch = FetchType.EAGER)
-    private Set<String> genres = new HashSet<>();
 
     protected Movie() {
     }
     
-    public Movie(String title) {
-        this(title, null, null);
+    public Movie(String title, String filePath) {
+        this(title, filePath, null);
     }
     
-    public Movie(String title, Double imdbRating, Set<String> genres) {
+    public Movie(String title, String filePath, Double imdbRating) {
         this.title = title;
+        this.filePath = filePath;
         this.imdbRating = imdbRating;
-        if(genres != null) {
-            this.genres = new HashSet<>(genres);
-        }
     }
 
     public String getTitle() {
@@ -52,7 +50,16 @@ public class Movie extends AbstractEntity {
         return imdbRating;
     }
 
-    public Set<String> getGenres() {
-        return Collections.unmodifiableSet(genres);
+    public String getFilePath() {
+        return filePath;
+    }
+
+    @Override
+    public String toString() {
+        return "Movie{" +
+                "title='" + title + '\'' +
+                ", filePath='" + filePath + '\'' +
+                ", imdbRating=" + imdbRating +
+                '}';
     }
 }

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/persistence/MovieRepository.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/persistence/MovieRepository.java
@@ -19,5 +19,7 @@ import org.springframework.data.repository.CrudRepository;
  */
 public interface MovieRepository extends CrudRepository<Movie, Long> {
     public Page<Movie> findByTitleContaining(String name, Pageable pageable);
+
+    public Movie findByFilePath(String filePath);
     
 }

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/service/FileThreadService.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/service/FileThreadService.java
@@ -17,7 +17,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.PreDestroy;
 import org.springframework.dao.DataIntegrityViolationException;
 
 /**
@@ -38,17 +40,22 @@ public class FileThreadService implements FileSystemListener{
     private LinkedList<WatchThread> threads;
 
     @PostConstruct
-    public void init() throws IOException {
+    public void init() {
         checkFolders = new LinkedList<>();
         checkFolders.add(new File("C:/film"));
         threads = new LinkedList<>();
         for(File f : checkFolders){  
-            threads.add(new WatchThread(f));
-            threads.getLast().setListener(this);
-            threads.getLast().start();
+            try {
+                threads.add(new WatchThread(f));
+                threads.getLast().setListener(this);
+                threads.getLast().start();
+            } catch (IOException ex) {
+                LOGGER.log(Level.SEVERE, null, ex);
+            }
         }
     }
     
+    @PreDestroy
     public void destory(){
         for(WatchThread t : threads){
             t.interrupt();

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/service/FileThreadService.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/service/FileThreadService.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Logger;
+import org.springframework.dao.DataIntegrityViolationException;
 
 /**
  *
@@ -64,7 +65,12 @@ public class FileThreadService implements FileSystemListener{
 
         TemporaryMedia temporaryMedia = titleParser.parseMedia(path);
         Movie movie = new Movie(temporaryMedia.getName(), path);
-        movieRepository.save(movie);
+        
+        try {
+            movieRepository.save(movie);
+        } catch (DataIntegrityViolationException e) {
+            // A Movie at this path already exist.
+        }
     }
 
     @Override
@@ -73,7 +79,11 @@ public class FileThreadService implements FileSystemListener{
 
         TemporaryMedia temporaryMedia = titleParser.parseMedia(path);
         Movie movie = new Movie(temporaryMedia.getName(), path);
-        movieRepository.save(movie);
+        try {
+            movieRepository.save(movie);
+        } catch (DataIntegrityViolationException e) {
+            // A Movie at this path already exist.
+        }
     }
 
     @Override

--- a/MovieFinder/src/main/resources/application.derby-db.properties
+++ b/MovieFinder/src/main/resources/application.derby-db.properties
@@ -1,0 +1,19 @@
+# JDBC Config
+####################
+jdbc.driverClassName=org.apache.derby.jdbc.ClientDriver
+jdbc.url=jdbc:derby://localhost:1527/MovieFinder;create=true
+jdbc.username=app
+jdbc.password=app
+
+
+# Hibernate Config
+####################
+hibernate.dialect=org.hibernate.dialect.DerbyTenSevenDialect
+# hbm2ddl.auto=update should make hibernate update schema if it changes
+hibernate.hbm2ddl.auto=update
+# Makes hibernate print queries it is doing, for debugging
+hibernate.show_sql=true
+# Formats the queries it prints
+hibernate.format_sql=true
+# Makes hibernate try to comment the printed queries, didn't really add much.
+hibernate.use_sql_comments=false

--- a/MovieFinder/src/main/resources/application.embedded-derby-db.properties
+++ b/MovieFinder/src/main/resources/application.embedded-derby-db.properties
@@ -1,0 +1,19 @@
+# JDBC Config
+####################
+jdbc.driverClassName=org.apache.derby.jdbc.EmbeddedDriver
+jdbc.url=jdbc:derby:derbyDB;create=true
+jdbc.username=
+jdbc.password=
+
+
+# Hibernate Config
+####################
+hibernate.dialect=org.hibernate.dialect.DerbyTenSevenDialect
+# hbm2ddl.auto=update should make hibernate update schema if it changes
+hibernate.hbm2ddl.auto=update
+# Makes hibernate print queries it is doing, for debugging
+hibernate.show_sql=true
+# Formats the queries it prints
+hibernate.format_sql=true
+# Makes hibernate try to comment the printed queries, didn't really add much.
+hibernate.use_sql_comments=false

--- a/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/persistence/MovieRepositoryIntegrationTest.java
+++ b/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/persistence/MovieRepositoryIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,6 +32,15 @@ public class MovieRepositoryIntegrationTest extends AbstractIntegrationTest {
     public void createMovie() {
         Movie movie = new Movie("MovieTest2", "movieTest2.avi");
         repository.save(movie);
+    }
+
+    @Test(expected = DataIntegrityViolationException.class)
+    public void createMultipleMoviesWithSameFilePath() {
+        // File path is unique, this should not be possible.
+        Movie m1 = new Movie("MovieTest2", "movieTest2.avi");
+        Movie m2 = new Movie("MovieTest3", "movieTest2.avi");
+        repository.save(m1);
+        repository.save(m2);
     }
     
     @Test

--- a/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/persistence/MovieRepositoryIntegrationTest.java
+++ b/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/persistence/MovieRepositoryIntegrationTest.java
@@ -29,7 +29,7 @@ public class MovieRepositoryIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void createMovie() {
-        Movie movie = new Movie("MovieTest2");
+        Movie movie = new Movie("MovieTest2", "movieTest2.avi");
         repository.save(movie);
     }
     
@@ -41,5 +41,11 @@ public class MovieRepositoryIntegrationTest extends AbstractIntegrationTest {
         
         assertThat(page.getContent(), hasSize(1));
         assertThat(page, Matchers.<Movie> hasItems(hasProperty("title", is("testMovie1"))));
+    }
+
+    @Test
+    public void findByFileName() {
+        Movie m = repository.findByFilePath("testMovie1.avi");
+        assertThat(m.getTitle(), is("testMovie1"));
     }
 }

--- a/MovieFinder/src/test/resources/data.sql
+++ b/MovieFinder/src/test/resources/data.sql
@@ -1,1 +1,1 @@
-insert into Movie (id, title) values (1, 'testMovie1');
+insert into Movie (id, title, filePath) values (1, 'testMovie1', 'testMovie1.avi');

--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ The build process requires a few tools to be already installed on the local mach
 git clone https://github.com/we4sz/DAT076.git
 ```
 
-### Step 2 - Package the application using maven
+### Step 2 - Set your database settings
+The application requries a database to run. As to allow for different database setups the database settings are stored in a gitignored settings file.
+
+Depending on what database setup you would like, choose one of the application.*.properites files in the `MovieFinder/src/main/resources/` directory and rename it to application.properties.
+
+### Step 3 - Package the application using maven
 
 ```
 cd MovieFinder


### PR DESCRIPTION
Simple File <-> DB <-> API example integration. 

Hooks into the file names returned from the WatchThread and adds those to the database. Also tries to update on filename changes. The resulting files can be seen by going to `/api/files/` (make sure to be logged in).

There is a bug/inconsistency with the path returned from WatchThread making this harder. The path parameter to the `initFile` method only contains the filename, while the path parameter to the two other methods contains the entire absolute path to the file:

```
17-Oct-2014 17:24:17.703 INFO [Thread-8] edu.chalmers.dat076.moviefinder.service.FileThreadService.initFile initFile: mina.fina.film.2014.avi
17-Oct-2014 17:24:48.368 INFO [Thread-8] edu.chalmers.dat076.moviefinder.service.FileThreadService.oldPath oldPath: C:\film\mina.fina.film.2014.avi
```

This PR also changes how the database settings are configured. Instead of having hard coded values the settings are instead read from a file called `application.properties`. **This file is not in git and must be created by copying one of the example files in the `MovieFinder/src/main/resources` directory and renaming it to `application.properties`**. This was done to allow for different local configurations. The non-embedded version is recommended but requires a running Derby database on the local computer (this can be done via NetBeans).
