### PR TITLE
Fetch from omdb

### DIFF
--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/model/OmdbMediaResponse.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/model/OmdbMediaResponse.java
@@ -4,7 +4,7 @@
  * and open the template in the editor.
  */
 
-package edu.chalmers.dat076.moviefinder.persistence;
+package edu.chalmers.dat076.moviefinder.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/persistence/OmdbMediaResponse.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/persistence/OmdbMediaResponse.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * A class for handling restful media response from OMDB
  *
- * @author Carl Jansson
+ * @author Carl Jansson, Peter Eliasson
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OmdbMediaResponse {

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/persistence/OmdbMediaResponse.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/persistence/OmdbMediaResponse.java
@@ -1,0 +1,216 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package edu.chalmers.dat076.moviefinder.persistence;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A class for handling restful media response from OMDB
+ *
+ * @author Carl Jansson
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OmdbMediaResponse {
+    
+    // OMDB result for: http://www.omdbapi.com/?t=True%20Grit&y=1969
+    /*
+     {"Title":"True Grit",
+     "Year":"1969"
+     ,"Rated":"N/A"
+     ,"Released":"11 Jun 1969",
+     "Runtime":"128 min",
+     "Genre":"Adventure, Western, Drama",
+     "Director":"Henry Hathaway",
+     "Writer":"Charles Portis (novel), Marguerite Roberts (screenplay)",
+     "Actors":"John Wayne, Glen Campbell, Kim Darby, Jeremy Slate",
+     "Plot":"A drunken, hard-nosed U.S. Marshal and a Texas Ranger help a stubborn young woman track down her father's murderer in Indian territory.",
+     "Language":"English",
+     "Country":"USA",
+     "Awards":"Won 1 Oscar. Another 7 wins & 5 nominations.",
+     "Poster":"http://ia.media-imdb.com/images/M/MV5BMTYwNTE3NDYzOV5BMl5BanBnXkFtZTcwNTU5MzY0MQ@@._V1_SX300.jpg",
+     "Metascore":"N/A",
+     "imdbRating":"7.4",
+     "imdbVotes":"28,457",
+     "imdbID":"tt0065126",
+     "Type":"movie",
+     "Response":"True"}
+     */
+    @JsonProperty("Title")
+    private String title;
+
+    @JsonProperty("Year")
+    private int year;
+
+    @JsonProperty("Rated")
+    private String rated;
+
+    @JsonProperty("Released")
+    private String released;
+
+    @JsonProperty("Runtime")
+    private String runtime;
+
+    @JsonProperty("Genre")
+    private String genre;
+
+    @JsonProperty("Director")
+    private String director;
+
+    @JsonProperty("Writer")
+    private String writer;
+
+    @JsonProperty("Actors")
+    private String actors;
+
+    @JsonProperty("Plot")
+    private String plot;
+
+    @JsonProperty("Language")
+    private String language;
+
+    @JsonProperty("Country")
+    private String country;
+
+    @JsonProperty("Awards")
+    private String awards;
+
+    @JsonProperty("Poster")
+    private String poster;
+
+    @JsonProperty("Metascore")
+    private String metascore;
+
+    @JsonProperty("imdbRating")
+    private Double imdbRating;
+
+    @JsonProperty("imdbVotes")
+    private String imdbVotes;
+
+    @JsonProperty("imdbID")
+    private String imdbID;
+
+    @JsonProperty("Type")
+    private String type;
+
+    @JsonProperty("Response")
+    private String response;
+
+    @JsonProperty("Error")
+    private String error;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public String getRated() {
+        return rated;
+    }
+
+    public String getReleased() {
+        return released;
+    }
+
+    public String getRuntime() {
+        return runtime;
+    }
+
+    public String getGenre() {
+        return genre;
+    }
+
+    public String getDirector() {
+        return director;
+    }
+
+    public String getWriter() {
+        return writer;
+    }
+
+    public String getActors() {
+        return actors;
+    }
+
+    public String getPlot() {
+        return plot;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public String getAwards() {
+        return awards;
+    }
+
+    public String getPoster() {
+        return poster;
+    }
+
+    public String getMetascore() {
+        return metascore;
+    }
+
+    public Double getImdbRating() {
+        return imdbRating;
+    }
+
+    public String getImdbVotes() {
+        return imdbVotes;
+    }
+
+    public String getImdbID() {
+        return imdbID;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getResponse() {
+        return response;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    @Override
+    public String toString() {
+        return "OmdbMovieResponse{"
+                + "title='" + title + '\''
+                + ", year='" + year + '\''
+                + ", rated='" + rated + '\''
+                + ", released='" + released + '\''
+                + ", runtime='" + runtime + '\''
+                + ", genre='" + genre + '\''
+                + ", director='" + director + '\''
+                + ", writer='" + writer + '\''
+                + ", actors='" + actors + '\''
+                + ", plot='" + plot + '\''
+                + ", language='" + language + '\''
+                + ", country='" + country + '\''
+                + ", awards='" + awards + '\''
+                + ", poster='" + poster + '\''
+                + ", metascore='" + metascore + '\''
+                + ", imdbRating='" + imdbRating + '\''
+                + ", imdbVotes='" + imdbVotes + '\''
+                + ", imdbID='" + imdbID + '\''
+                + ", type='" + type + '\''
+                + ", response='" + response + '\''
+                + ", error='" + error + '\''
+                + '}';
+    }
+}

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/utils/OmdbHandler.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/utils/OmdbHandler.java
@@ -5,7 +5,7 @@
  */
 package edu.chalmers.dat076.moviefinder.utils;
 
-import edu.chalmers.dat076.moviefinder.persistence.OmdbMediaResponse;
+import edu.chalmers.dat076.moviefinder.model.OmdbMediaResponse;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.http.MediaType;

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/utils/OmdbHandler.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/utils/OmdbHandler.java
@@ -16,7 +16,7 @@ import org.springframework.web.client.RestTemplate;
 
 /**
  *
- * @author Carl Jansson
+ * @author Carl Jansson, Peter Eliasson
  */
 public class OmdbHandler {
     
@@ -53,8 +53,11 @@ public class OmdbHandler {
      * @param title
      * @return the most recent movie with the best title match
      */
-    public OmdbMediaResponse getOMDB(String title){
+    public OmdbMediaResponse getOMDB(String title) throws NullPointerException{
         OmdbMediaResponse movie = restTemplate.getForObject("http://www.omdbapi.com/?t=" + title, OmdbMediaResponse.class);
+        if ( movie.getTitle() == null ) {
+            throw new NullPointerException();
+        }
         return movie;
     }
     
@@ -64,8 +67,11 @@ public class OmdbHandler {
      * @param year
      * @return the biggest thing from the year with the best title match
      */
-    public OmdbMediaResponse getOMDB(String title, int year){
+    public OmdbMediaResponse getOMDB(String title, int year) throws NullPointerException{
         OmdbMediaResponse movie = restTemplate.getForObject("http://www.omdbapi.com/?t=" + title + "&y=" + year, OmdbMediaResponse.class);
+        if ( movie.getTitle() == null ) {
+            throw new NullPointerException();
+        }
         return movie;
     }
     
@@ -74,8 +80,11 @@ public class OmdbHandler {
      * @param imdbID
      * @return The omdb thing with the right imdbID
      */
-    public OmdbMediaResponse getMoreOMDB(String imdbID){
+    public OmdbMediaResponse getMoreOMDB(String imdbID) throws NullPointerException{
         OmdbMediaResponse movie = restTemplate.getForObject("http://www.omdbapi.com/?i=" + imdbID, OmdbMediaResponse.class);
+        if ( movie.getTitle() == null ) {
+            throw new NullPointerException();
+        }
         return movie;
     }
     

--- a/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/utils/OmdbHandler.java
+++ b/MovieFinder/src/main/java/edu/chalmers/dat076/moviefinder/utils/OmdbHandler.java
@@ -1,0 +1,82 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package edu.chalmers.dat076.moviefinder.utils;
+
+import edu.chalmers.dat076.moviefinder.persistence.OmdbMediaResponse;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ *
+ * @author Carl Jansson
+ */
+public class OmdbHandler {
+    
+    RestTemplate restTemplate;
+    
+    public OmdbHandler(){
+        init();
+    }
+    
+    /*
+    configure RestTemplate so it can reseive text/html as json
+    */
+    private void init(){
+        restTemplate = new RestTemplate();
+        
+        MappingJackson2HttpMessageConverter jacksonConverter = new MappingJackson2HttpMessageConverter();
+        
+        // OMDB returns json but with the HTTP Content-Type header set to "text/html",
+        // so we have to add that as an accepted contet type for our jackson converter
+        // or it will not trigger for the response
+        List<MediaType> mediaTypes = new ArrayList<>();
+        mediaTypes.add(new MediaType("text", "html", AbstractJackson2HttpMessageConverter.DEFAULT_CHARSET));
+        jacksonConverter.setSupportedMediaTypes(mediaTypes);
+        
+        // Add the custom jacksonConverter to the available messageConverters
+        // of the restTemplate
+        List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
+        messageConverters.add(jacksonConverter);
+        restTemplate.setMessageConverters(messageConverters);
+    }
+    
+    /**
+     * 
+     * @param title
+     * @return the most recent movie with the best title match
+     */
+    public OmdbMediaResponse getOMDB(String title){
+        OmdbMediaResponse movie = restTemplate.getForObject("http://www.omdbapi.com/?t=" + title, OmdbMediaResponse.class);
+        return movie;
+    }
+    
+    /**
+     * 
+     * @param title
+     * @param year
+     * @return the biggest thing from the year with the best title match
+     */
+    public OmdbMediaResponse getOMDB(String title, int year){
+        OmdbMediaResponse movie = restTemplate.getForObject("http://www.omdbapi.com/?t=" + title + "&y=" + year, OmdbMediaResponse.class);
+        return movie;
+    }
+    
+    /**
+     * 
+     * @param imdbID
+     * @return The omdb thing with the right imdbID
+     */
+    public OmdbMediaResponse getMoreOMDB(String imdbID){
+        OmdbMediaResponse movie = restTemplate.getForObject("http://www.omdbapi.com/?i=" + imdbID, OmdbMediaResponse.class);
+        return movie;
+    }
+    
+}

--- a/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/utils/OmdbHandlerTest.java
+++ b/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/utils/OmdbHandlerTest.java
@@ -71,8 +71,13 @@ public class OmdbHandlerTest {
         assertEquals("tt0076759", result.getImdbID());
         
         title = "absolotely nonsense asdfasdfs";
-        result = instance.getOMDB(title, year);
-        assertEquals(null, result.getTitle());
+        try {
+            result = instance.getOMDB(title, year);
+            fail("exception not cast by: absolotely nonsense asdfasdfs");
+        } catch (NullPointerException e){
+            // Deafault not failing
+        }
+        
     }
     
     @Test
@@ -89,7 +94,6 @@ public class OmdbHandlerTest {
         result = instance.getMoreOMDB(imdbID);
         assertEquals("True Grit", result.getTitle());
         assertEquals(1969, result.getYear());
-        
         
     }
 }

--- a/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/utils/OmdbHandlerTest.java
+++ b/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/utils/OmdbHandlerTest.java
@@ -6,7 +6,7 @@
 
 package edu.chalmers.dat076.moviefinder.utils;
 
-import edu.chalmers.dat076.moviefinder.persistence.OmdbMediaResponse;
+import edu.chalmers.dat076.moviefinder.model.OmdbMediaResponse;
 import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/utils/OmdbHandlerTest.java
+++ b/MovieFinder/src/test/java/edu/chalmers/dat076/moviefinder/utils/OmdbHandlerTest.java
@@ -1,0 +1,95 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package edu.chalmers.dat076.moviefinder.utils;
+
+import edu.chalmers.dat076.moviefinder.persistence.OmdbMediaResponse;
+import static org.junit.Assert.*;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ * @author Carl Jansson
+ */
+public class OmdbHandlerTest {
+    
+    private static OmdbHandler instance;
+    
+    public OmdbHandlerTest() {
+    }
+    
+    @BeforeClass
+    public static void setUpClass() {
+        instance = new OmdbHandler();
+    }
+        
+    /**
+     * Test of getOMDB method, of class OMDBinfo.
+     */
+    @Test
+    public void testGetOMDB() {
+        String title;
+        int year;
+        OmdbMediaResponse result;
+        
+        title = "True Grit";
+        result = instance.getOMDB(title);
+        assertEquals("tt1403865", result.getImdbID());
+        
+        year = 2010;
+        result = instance.getOMDB(title, year);
+        assertEquals("tt1403865", result.getImdbID());
+        
+        year = 1969;
+        result = instance.getOMDB(title, year);
+        assertEquals("tt0065126", result.getImdbID());
+        
+        title = "Star Wars: Episode IV - A New Hope";
+        result = instance.getOMDB(title);
+        assertEquals("tt0076759", result.getImdbID());
+        
+        title = "Star Wars Episode IV A New Hope";
+        result = instance.getOMDB(title);
+        assertEquals("tt0076759", result.getImdbID());
+        
+        // Parser could remove the '-' with 3 ' ' as result
+        title = "Star Wars: Episode IV   A New Hope";
+        result = instance.getOMDB(title);
+        assertEquals("tt0076759", result.getImdbID());
+        
+        title = "Star Wars";
+        year = 1977;
+        result = instance.getOMDB(title, year);
+        assertEquals("tt0076759", result.getImdbID());
+        
+        title = "Star Wars Episode IV";
+        result = instance.getOMDB(title, year);
+        assertEquals("tt0076759", result.getImdbID());
+        
+        title = "absolotely nonsense asdfasdfs";
+        result = instance.getOMDB(title, year);
+        assertEquals(null, result.getTitle());
+    }
+    
+    @Test
+    public void testGetMoreOMDB() {
+        String imdbID;
+        OmdbMediaResponse result;
+        
+        imdbID = "tt1403865";
+        result = instance.getMoreOMDB(imdbID);
+        assertEquals("True Grit", result.getTitle());
+        assertEquals(2010, result.getYear());
+        
+        imdbID = "tt0065126";
+        result = instance.getMoreOMDB(imdbID);
+        assertEquals("True Grit", result.getTitle());
+        assertEquals(1969, result.getYear());
+        
+        
+    }
+}


### PR DESCRIPTION
OmdbHandler can now be used to get data from OMDB. It is possible to search by title, title + year or a unique imdbID. If media is found it is returned as OmdbMediaResponse and if no media is found a NullPointerException is thrown.

It is recommended to only use OMDB when searching for movies due to no reliable way to search for individual episodes in series.
